### PR TITLE
Fix: Don't display fitting for POS modules

### DIFF
--- a/EDKlibs/class.itemlist.php
+++ b/EDKlibs/class.itemlist.php
@@ -84,46 +84,46 @@ class ItemList
 			return;
 		}
 		$sql = "select inv.icon, inv.typeID,
-				itp.price, kb3_item_types.*, dga.value as metalevel, dgb.value as techlevel,
-				dc.value as usedcharge, dl.value as usedlauncher,
-				inv.groupID, inv.typeName, inv.capacity, inv.raceID, inv.mass, inv.volume,
-				inv.basePrice, inv.marketGroupID";
+                            itp.price, kb3_item_types.*, dga.value as metalevel, dgb.value as techlevel,
+                            dc.value as usedcharge, dl.value as usedlauncher,
+                            inv.groupID, inv.typeName, inv.capacity, inv.raceID, inv.mass, inv.volume,
+                            inv.basePrice, inv.marketGroupID";
 		if (count($this->destroyedIDarray)) {
-			$sql .= ", if(dl.attributeID IS NULL,sum(itd.itd_quantity),
-					truncate(sum(itd.itd_quantity)/count(dl.attributeID),0))
-					as itd_quantity, itd_itm_id, itd_itl_id, itl_flagText ";
+			$sql .= ", if(dl.attributeID IS NULL,sum(itd.itd_quantity),"
+					."truncate(sum(itd.itd_quantity)/count(dl.attributeID),0)) "
+					."as itd_quantity, itd_itm_id, itd_itl_id, itl_flagText, itd_singleton ";
 		} else if (count($this->droppedIDarray)) {
-			$sql .= ", if(dl.attributeID IS NULL,sum(itd.itd_quantity),
-					truncate(sum(itd.itd_quantity)/count(dl.attributeID),0))
-					as itd_quantity, itd_itm_id, itd_itl_id, itl_flagText ";
+			$sql .= ", if(dl.attributeID IS NULL,sum(itd.itd_quantity),"
+					."truncate(sum(itd.itd_quantity)/count(dl.attributeID),0)) "
+					."as itd_quantity, itd_itm_id, itd_itl_id, itl_flagText, itd_singleton ";
 		}
 
 		$sql .= "from kb3_invtypes inv
-				left join kb3_dgmtypeattributes dga on dga.typeID=inv.typeID and dga.attributeID=633
-				left join kb3_dgmtypeattributes dgb on dgb.typeID=inv.typeID and dgb.attributeID=422
-				left join kb3_item_price itp on itp.typeID=inv.typeID
-				left join kb3_item_types on inv.groupID=itt_id
-				left join kb3_dgmtypeattributes dc on dc.typeID = inv.typeID AND dc.attributeID IN (128)
-				left join kb3_dgmtypeattributes dl on dl.typeID = inv.typeID AND dl.attributeID IN (137,602) ";
+                            left join kb3_dgmtypeattributes dga on dga.typeID=inv.typeID and dga.attributeID=633
+                            left join kb3_dgmtypeattributes dgb on dgb.typeID=inv.typeID and dgb.attributeID=422
+                            left join kb3_item_price itp on itp.typeID=inv.typeID
+                            left join kb3_item_types on inv.groupID=itt_id
+                            left join kb3_dgmtypeattributes dc on dc.typeID = inv.typeID AND dc.attributeID IN (128)
+                            left join kb3_dgmtypeattributes dl on dl.typeID = inv.typeID AND dl.attributeID IN (137,602) ";
 
 		if (count($this->destroyedIDarray)) {
-			$sql .= "join kb3_items_destroyed itd on inv.typeID = itd_itm_id
-					and itd_kll_id in (
-					".implode(',', $this->destroyedIDarray).")
-					left join kb3_item_locations itl
-					on (itd.itd_itl_id = itl.itl_flagID )";
+			$sql .= "join kb3_items_destroyed itd on inv.typeID = itd_itm_id "
+					."and itd_kll_id in ("
+					.implode(',', $this->destroyedIDarray).") "
+					."left join kb3_item_locations itl "
+					."on (itd.itd_itl_id = itl.itl_flagID )";
 		} else if (count($this->droppedIDarray)) {
-			$sql .= "join kb3_items_dropped itd
-					on inv.typeID = itd_itm_id and itd_kll_id in (
-					".implode(',', $this->droppedIDarray).")
-					left join kb3_item_locations itl
-					on (itd.itd_itl_id = itl.itl_flagID ) ";
+			$sql .= "join kb3_items_dropped itd "
+					."on inv.typeID = itd_itm_id and itd_kll_id in ("
+					.implode(',', $this->droppedIDarray).") "
+					."left join kb3_item_locations itl "
+					."on (itd.itd_itl_id = itl.itl_flagID ) ";
 		} else {
 			$sql .= "where inv.typeID in (".implode(',', $this->itemarray).") ";
 		}
 
 		if (count($this->destroyedIDarray) || count($this->droppedIDarray)) {
-			$sql .= "group by itd.itd_itm_id, itd.itd_itl_id "
+			$sql .= "group by itd.itd_itm_id, itd.itd_itl_id, itd.itd_singleton "
 					."order by itd.itd_itl_id ";
 		}
 

--- a/Libs/Fitting.class.php
+++ b/Libs/Fitting.class.php
@@ -29,6 +29,19 @@ class Fitting
 		self::$shipStats = new Shipstats();
 	}
 
+	public function sortSlots($a, $b)
+	{
+		return	
+			Statistics::slots($a->item_->getAttribute("itt_slot"), $a->item_->getAttribute('itl_flagText'), $a->item_->getAttribute('itt_cat'))
+			-
+			Statistics::slots($b->item_->getAttribute("itt_slot"), $b->item_->getAttribute('itl_flagText'), $b->item_->getAttribute('itt_cat'));
+	}
+	
+	
+	public function sortItemsInSlotsByName($a, $b)
+	{
+		return strcmp($a['name'], $b['name']);
+	}
 
 /**
  * buildFit method
@@ -41,12 +54,7 @@ class Fitting
 		$arr = array();
 
 		if($_fit) {
-			usort($_fit, function($a, $b) {
-				return
-					Statistics::slots($a->item_->getAttribute("itt_slot"), $a->item_->getAttribute('itl_flagText'), $a->item_->getAttribute('itt_cat'))
-					-
-					Statistics::slots($b->item_->getAttribute("itt_slot"), $b->item_->getAttribute('itl_flagText'), $b->item_->getAttribute('itt_cat'));
-			});
+			usort($_fit, array('Fitting', 'sortSlots'));
 
 			foreach($_fit as $head => $mods) {
 				if(in_array($mods->item_->getAttribute("typeID"), $this->ignoreMods)) continue;
@@ -99,7 +107,6 @@ class Fitting
 							if(self::advancedModuleSettings(strtolower($mods->item_->getAttribute("typeName"))) == "ab") {
 								self::$shipStats->setIsAB(true);
 							}
-
 							for($i = 0; $i < $mods->item_->getAttribute('itd_quantity'); $i++) {
 								self::$modSlots[$slot][self::$shipStats->moduleCount] = $this->moduleInformation($slot, $mods);
 								self::buildSettings($slot, $mods, $modData);
@@ -128,7 +135,6 @@ class Fitting
 
 						foreach(self::$modSlots[1] as $m => $module) {
 							if($ammocharge == $module["groupID"] || ($module["groupID"] == 511 && $ammocharge == 509) || ($module["groupID"] == 1245 && $ammocharge == 510)) {// Assault Missile Lauchers uses same ammo as Standard Missile Lauchers
-								self::$modSlots[10][$m] = $this->moduleInformation(10, $ammo);
 								self::buildSettings(10, $ammo, $modData);
 							}
 						}
@@ -166,24 +172,16 @@ class Fitting
 				}
 			}
 			if(Fitting::$modSlots[1]) {
-				usort(Fitting::$modSlots[1], function ($a, $b){
-					return strcmp($a['name'], $b['name']);
-				});
+				usort(Fitting::$modSlots[1], array('Fitting', 'sortItemsInSlotsByName'));
 			}
 			if(Fitting::$modSlots[2]) {
-				usort(Fitting::$modSlots[2], function ($a, $b){
-					return strcmp($a['name'], $b['name']);
-				});
+				usort(Fitting::$modSlots[2], array('Fitting', 'sortItemsInSlotsByName'));
 			}
 			if(Fitting::$modSlots[3]) {
-				usort(Fitting::$modSlots[3], function ($a, $b){
-					return strcmp($a['name'], $b['name']);
-				});
+				usort(Fitting::$modSlots[3], array('Fitting', 'sortItemsInSlotsByName'));
 			}
 			if(Fitting::$modSlots[5]) {
-				usort(Fitting::$modSlots[5], function ($a, $b){
-					return strcmp($a['name'], $b['name']);
-				});
+				usort(Fitting::$modSlots[5], array('Fitting', 'sortItemsInSlotsByName'));
 			}
 
 
@@ -308,7 +306,7 @@ class Fitting
 			FROM kb3_invtraits a
 			LEFT JOIN kb3_eveunits b
 			ON b.unitID = a.unitID
-			WHERE a.typeID = ".$_typeID);
+			WHERE a.typeID = ".$_typeID." AND a.skillID > 0"); // don't handle role bonuses at all
 
 
 		while($row = $qry2->getRow()) {
@@ -1642,7 +1640,8 @@ class Fitting
 			if($groupID == "774") {
 				self::$shipStats->shieldDur = Statistics::modShieldDur(self::$shipStats->shieldDur, self::$shipStats->moduleCount, $bonus, "-", self::$shipStats->shieldAmp, true);
 			} else {
-				self::$shipStats->armorDur = Statistics::modShieldDur(self::$shipStats->armorDur, self::$shipStats->moduleCount, $bonus, "-", $stack = 1);
+$one = 1;
+				self::$shipStats->armorDur = Statistics::modShieldDur(self::$shipStats->armorDur, self::$shipStats->moduleCount, $bonus, "-", $one);
 			}
 		} else if($effect == "drawback") {
 			if($groupID == "773") {

--- a/Libs/Statistics.class.php
+++ b/Libs/Statistics.class.php
@@ -98,7 +98,8 @@ class Statistics
  * @return (array)
  */
 	public static function modOrdering($_arr, &$_sensorbooster, $_scan, $_range) {
-		$_arr[$_sensorbooster[0]]['scan'] = ($_scan)?$_arr[$_sensorbooster[0]]['range']*2:0;
+
+		$_arr[$_sensorbooster[0]]['scan'] = ($_scan)?$_arr[$_sensorbooster[0]]['scan']*2:0;
 		$_arr[$_sensorbooster[0]]['range'] = ($_range)?$_arr[$_sensorbooster[0]]['range']*2:0;
 
 		unset($_sensorbooster[0]);

--- a/init.php
+++ b/init.php
@@ -308,13 +308,13 @@ class FittingTools {
 		$fitter = new Fitting($kll_id);
 		$fitter->getShipStats($shipname);
 		// POS modules don't have any fitting
-		if($shipclass->getID() == 38)
+		if($shipclass->getID() == 38) 
 		{
-		   $fitter->buildFit(array());
+			$fitter->buildFit(array());
 		}
 		else
 		{
-		   $fitter->buildFit(array_merge($km->getDestroyedItems(), $km->getDroppedItems()));
+			$fitter->buildFit(array_merge($km->getDestroyedItems(), $km->getDroppedItems()));
 		}
 
 		$victimShipClassName = $shipclass->getName();
@@ -415,7 +415,7 @@ class FittingTools {
 			$type = "URL";
 			$source = substr($source, 3);
 		} else if (preg_match("/^ZKB:http/", $source)) {
-			$type = "CREST";
+			$type = "URL";
 			$source = substr($source, 4);
 		} else {
 			$type = "unknown";
@@ -1249,14 +1249,11 @@ class FittingTools {
 			$arr[$i]['capNeeded'] = $cap;
 			$arr[$i]['type'] = $value['type'];
 			$arr[$i]['duration'] = $value['duration'];
-
 			if($cap != 0 && $value['duration'] != 0) {
-				$arr[$i]['use'] = $cap/$value['duration'];
+ 				$arr[$i]['use'] = $cap/$value['duration'];
 			} else {
-				$arr[$i]['use'] = 0;
-			}
-
-
+ 				$arr[$i]['use'] = 0;
+ 			}
 		}
 
 		return $arr;
@@ -1385,7 +1382,6 @@ class FittingTools {
 				if($total != 0) {
 					$arr[$i]['dps'] = ($total/$averagedps);
 				}
-				//\Misc::pre($arr);
 				Fitting::$shipStats->setDamageGun($arr);
 			}
 		}
@@ -1418,7 +1414,7 @@ class FittingTools {
 			if($dex != "M") {
 				$rof = self::setDamageModSkills("rof".$dex, $value['rof'.$dex], $value['techlevel']);
 				$dMod = self::setDamageModSkills("damage".$dex, $value['damage'.$dex], $value['techlevel']);
-				//echo $rof." - ".$dMod." - ".$value['damage'.$dex]."<br />";
+				//echo $rof." - ".$dMod;
 
 				$em = $value['emDamage'];
 				$ex = $value['exDamage'];
@@ -1436,6 +1432,7 @@ class FittingTools {
 				|| Fitting::$shipStats->getShipIcon() == 4308) {
 					Fitting::$shipStats->setRSize("Large");
 				}
+
 				if(self::isSmartBomb(strtolower($value['name']))) {
 					$rof = Calculations::statOntoShip($rof, 25,"-","%", 1);
 				}
@@ -1448,7 +1445,7 @@ class FittingTools {
 							|| $effect['effect'] == "rofL") {
 								if($dex == "P") {
 									if($effect['type'] == "=") {
-										$rof = Calculations::statOntoShip($rof, $effect['bonus'],"-","%", 1);
+										 $rof = Calculations::statOntoShip($rof, $effect['bonus'],"-","%", 1);
 									} else {
 										$rof = Calculations::statOntoShip($rof, (5*$effect['bonus']),"-","%", 1);
 									}

--- a/init.php
+++ b/init.php
@@ -307,7 +307,15 @@ class FittingTools {
 
 		$fitter = new Fitting($kll_id);
 		$fitter->getShipStats($shipname);
-		$fitter->buildFit(array_merge($km->getDestroyedItems(), $km->getDroppedItems()));
+		// POS modules don't have any fitting
+		if($shipclass->getID() == 38)
+		{
+		   $fitter->buildFit(array());
+		}
+		else
+		{
+		   $fitter->buildFit(array_merge($km->getDestroyedItems(), $km->getDroppedItems()));
+		}
 
 		$victimShipClassName = $shipclass->getName();
 		$timeStamp = $km->getTimeStamp();

--- a/init.php
+++ b/init.php
@@ -306,17 +306,16 @@ class FittingTools {
 
 
 		$fitter = new Fitting($kll_id);
-		$fitter->getShipStats($shipname);
-		// POS modules don't have any fitting
-		if($shipclass->getID() == 38) 
-		{
-			$fitter->buildFit(array());
+		if((config::get('ship_display_pods')) && ($ship->getExternalID() == '670' || $ship->getExternalID() == '33328')) {
+			$fitpod = true;
 		}
 		else
 		{
-			$fitter->buildFit(array_merge($km->getDestroyedItems(), $km->getDroppedItems()));
+			$fitpod = false;
 		}
-
+		$fitter->getShipStats($shipname, $fitpod);
+		$fitter->buildFit(array_merge($km->getDestroyedItems(), $km->getDroppedItems()), $fitpod);
+		
 		$victimShipClassName = $shipclass->getName();
 		$timeStamp = $km->getTimeStamp();
 		$victimShipID = edkURI::page('invtype', $ship->getExternalID(), 'id');
@@ -1250,10 +1249,10 @@ class FittingTools {
 			$arr[$i]['type'] = $value['type'];
 			$arr[$i]['duration'] = $value['duration'];
 			if($cap != 0 && $value['duration'] != 0) {
- 				$arr[$i]['use'] = $cap/$value['duration'];
+				$arr[$i]['use'] = $cap/$value['duration'];
 			} else {
- 				$arr[$i]['use'] = 0;
- 			}
+				$arr[$i]['use'] = 0;
+			}
 		}
 
 		return $arr;
@@ -1414,7 +1413,7 @@ class FittingTools {
 			if($dex != "M") {
 				$rof = self::setDamageModSkills("rof".$dex, $value['rof'.$dex], $value['techlevel']);
 				$dMod = self::setDamageModSkills("damage".$dex, $value['damage'.$dex], $value['techlevel']);
-				//echo $rof." - ".$dMod;
+				//echo $rof." - ".$dMod." - ".$value['damage'.$dex]."<br />";
 
 				$em = $value['emDamage'];
 				$ex = $value['exDamage'];
@@ -1432,7 +1431,6 @@ class FittingTools {
 				|| Fitting::$shipStats->getShipIcon() == 4308) {
 					Fitting::$shipStats->setRSize("Large");
 				}
-
 				if(self::isSmartBomb(strtolower($value['name']))) {
 					$rof = Calculations::statOntoShip($rof, 25,"-","%", 1);
 				}
@@ -1445,7 +1443,7 @@ class FittingTools {
 							|| $effect['effect'] == "rofL") {
 								if($dex == "P") {
 									if($effect['type'] == "=") {
-										 $rof = Calculations::statOntoShip($rof, $effect['bonus'],"-","%", 1);
+										$rof = Calculations::statOntoShip($rof, $effect['bonus'],"-","%", 1);
 									} else {
 										$rof = Calculations::statOntoShip($rof, (5*$effect['bonus']),"-","%", 1);
 									}

--- a/settings.php
+++ b/settings.php
@@ -30,7 +30,7 @@ if($backgroundimg == "") {
 	$backgroundimg = "#222222";
 }
 $html .= "<br />
-<form name=\"add\" action=\"?a=settings_ship_tool_kb&amp;step=add\" method=\"post\"><br /><br />
+<form name=\"add\" action=\"?a=settings_ship_display_tool&amp;step=add\" method=\"post\"><br /><br />
 	<div style='float:left; width:100%;'>Select your mod background colour in hash, Example: #ffffff: <input type='text' name='sel_back' value='".$backgroundimg."' /></div>
 	<div style='float:left; width:100%;'><input type=\"submit\" value=\"save\" /></div>
 </form>
@@ -51,7 +51,7 @@ if ($_POST) {
 
   config::set('ship_display_back', $tool_back);
 
-  Header("Location: ?a=settings_ship_tool_kb");
+  Header("Location: ?a=settings_ship_display_tool");
 }
 
 

--- a/settings.php
+++ b/settings.php
@@ -20,6 +20,17 @@ $(document).ready(function(){
 });
 </script>";*/
 
+if ($_POST) {
+  $tool_back = $_POST["sel_back"];
+  $tool_pods = ($_POST["fit_pods"]) ? 1 : 0;
+
+
+  config::set('ship_display_back', $tool_back);
+  config::set('ship_display_pods', $tool_pods);
+//  Header("Location: ?a=settings_ship_display_tool");
+}
+
+
 $page = new Page('Ship Display tool - Settings');
 
 $html .= "Ship Display Tool Admin page.<br />Created by Spark's.<br />Enjoy.";
@@ -30,9 +41,16 @@ if($backgroundimg == "") {
 	$backgroundimg = "#222222";
 }
 $html .= "<br />
-<form name=\"add\" action=\"?a=settings_ship_display_tool&amp;step=add\" method=\"post\"><br /><br />
-	<div style='float:left; width:100%;'>Select your mod background colour in hash, Example: #ffffff: <input type='text' name='sel_back' value='".$backgroundimg."' /></div>
-	<div style='float:left; width:100%;'><input type=\"submit\" value=\"save\" /></div>
+<form name=options id=options method=post action=><br /><br />
+	<div style='float:left; width:100%;'>Select your mod background colour in hash, Example: #ffffff: <input type='text' name='sel_back' value='".$backgroundimg."' /></div>";
+$html .= "<div style='float:left; width:100%;'>Fit Implants to Pods:<input type=checkbox name='fit_pods' id='fit_pods'";
+if (config::get('ship_display_pods'))
+{
+    $html .= " checked=\"checked\"";
+}
+
+$html .= "	/><br /><br /></div>
+<div style='float:left; width:100%;'><input type=\"submit\" value=\"Save\" /></div>
 </form>
 ";
 
@@ -40,20 +58,6 @@ $html .= "<br />
 
 
 $html .= "<br /><br />Remember to report bugs to this post: <a href='http://eve-id.net/forum/viewtopic.php?f=505&t=17295'>http://eve-id.net/forum/viewtopic.php?f=505&t=17295</a>.<br /><br />Thanks";
-
-
-
-
-
-if ($_POST) {
-  $tool_back = $_POST["sel_back"];
-
-
-  config::set('ship_display_back', $tool_back);
-
-  Header("Location: ?a=settings_ship_display_tool");
-}
-
 
 
 $page->setContent($html);

--- a/ship_display_tool.tpl
+++ b/ship_display_tool.tpl
@@ -126,7 +126,7 @@
 
 						<ul id="km_posting">
 							<li>API: <span>{if (bool)$extid}Yes{else}No{/if}</span></li>
-							<li>Source: <span>{if $type == "API"}API{else if $type == "IP"}Manual{else if $type == "URL"}Fetch{else if $type == "CREST"}CREST{/if}</span></li>
+							<li>Source: <span>{if $type == "API"}API{else if $type == "IP"}Manual{else if $type == "URL"}Fetch{/if}</span></li>
 							<li>Damage: <span>{$getPilotDam}</span></li>
 							<li>Cost: <span>{$getPilotCos} isk</span></li>
 						</ul>


### PR DESCRIPTION
Modules fitted on ships in Ship Maintenance Arrays get the inventory flag
0, which is usually reserved for "default location". That lead to Ship
Maintenance Arrays with guns, triple shield boosters and overdrives.

Added a check for the ship class to omit any fitting for POS modules.
